### PR TITLE
Add incoming leads endpoint

### DIFF
--- a/refer-backend/README.md
+++ b/refer-backend/README.md
@@ -1,0 +1,23 @@
+# Refer Backend API
+
+All endpoints are prefixed with `/api`.
+
+## Auth
+- `POST /api/auth/register` - register a new user.
+- `POST /api/auth/login` - login and receive a JWT token.
+
+## Services
+- `POST /api/services/` - create a new service (authenticated).
+- `GET /api/services/mine` - list services created by the authenticated user.
+
+## Friends
+- `POST /api/friends/` - add a friend by email.
+- `GET /api/friends/` - list your friends.
+- `GET /api/friends/services` - services offered by your friends.
+
+## Leads
+- `POST /api/leads/` - submit a lead to a friend's service.
+- `GET /api/leads/mine` - leads you have sent.
+- `GET /api/leads/for-me` - leads sent to your services.
+- `POST /api/leads/:id/status` - update a lead's status (service owner).
+

--- a/refer-backend/controllers/leadsController.js
+++ b/refer-backend/controllers/leadsController.js
@@ -56,6 +56,30 @@ async function getMyLeads(req, res) {
     res.status(500).json({ error: "Failed to load leads" });
   }
 }
+
+// Get leads submitted to services owned by the current user
+async function getIncomingLeads(req, res) {
+  const ownerId = req.user.id;
+
+  try {
+    const result = await pool.query(
+      `SELECT leads.id, leads.note, leads.status, leads.created_at,
+              services.title AS service_title,
+              users.name AS sender_name
+       FROM leads
+       JOIN services ON services.id = leads.service_id
+       JOIN users ON users.id = leads.sender_id
+       WHERE services.user_id = $1
+       ORDER BY leads.created_at DESC`,
+      [ownerId]
+    );
+
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to load incoming leads" });
+  }
+}
 async function updateLeadStatus(req, res) {
   const userId = req.user.id;
   const leadId = req.params.id;
@@ -81,5 +105,6 @@ async function updateLeadStatus(req, res) {
 module.exports = {
   createLead,
   getMyLeads,
+  getIncomingLeads,
   updateLeadStatus,
 };

--- a/refer-backend/routes/leadRoutes.js
+++ b/refer-backend/routes/leadRoutes.js
@@ -1,11 +1,17 @@
 const express = require("express");
-const { createLead, getMyLeads, updateLeadStatus} = require("../controllers/leadsController");
+const {
+  createLead,
+  getMyLeads,
+  getIncomingLeads,
+  updateLeadStatus,
+} = require("../controllers/leadsController");
 const authenticate = require("../middleware/auth");
 
 const router = express.Router();
 
 router.post("/", authenticate, createLead);
 router.get("/mine", authenticate, getMyLeads);
+router.get("/for-me", authenticate, getIncomingLeads);
 router.post("/:id/status", authenticate, updateLeadStatus);
 
 


### PR DESCRIPTION
## Summary
- implement `getIncomingLeads` controller
- route `/for-me` for listing leads sent to current user's services
- document backend API including the new endpoint

## Testing
- `npm test` in `refer-backend` *(fails: no test specified)*
- `npm test` in `refer-app` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ca1ba33b48322b4d036b750f6fddc