### PR TITLE
Add configurable API base URL

### DIFF
--- a/refer-app/.env.example
+++ b/refer-app/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:3000/api

--- a/refer-app/src/api/axiosClient.js
+++ b/refer-app/src/api/axiosClient.js
@@ -1,7 +1,8 @@
 import axios from "axios";
 
 const axiosClient = axios.create({
-  baseURL: "http://localhost:3000/api",
+  // Read base URL from environment to allow configurable backends
+  baseURL: import.meta.env.VITE_API_BASE || "http://localhost:3000/api",
   withCredentials: false, // set to true if using cookies
 });
 


### PR DESCRIPTION
## Summary
- make axios base URL configurable using `VITE_API_BASE`
- add `.env.example` for the frontend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ca1c1b45083228410395b1e40e0c9