### PR TITLE
Use axios client everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This repository contains a simple referral tracking application with a React fro
    cd refer-app
    npm install
    ```
-2. The frontend uses `src/api/axiosClient.js` to contact the backend. Update the `baseURL` there if your backend runs on a different host or port.
+2. The frontend uses `src/api/axiosClient.js` to contact the backend. The base URL is controlled by the `VITE_API_BASE` environment variable. Create a `.env` file (or edit `.env.example`) if your backend runs on a different host or port.
 3. Run the development server:
    ```bash
    npm run dev

--- a/refer-app/src/pages/Login.jsx
+++ b/refer-app/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useAuth } from "../context/AuthContext";
-import axios from "axios";
+import axios from "../api/axiosClient";
 
 export default function Login() {
   const { login } = useAuth();
@@ -10,7 +10,7 @@ export default function Login() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post("http://localhost:3000/api/auth/login", {
+      const res = await axios.post("/auth/login", {
         email,
         password,
       });

--- a/refer-app/src/pages/Register.jsx
+++ b/refer-app/src/pages/Register.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useAuth } from "../context/AuthContext";
-import axios from "axios";
+import axios from "../api/axiosClient";
 
 export default function Register() {
   const { login } = useAuth();
@@ -11,7 +11,7 @@ export default function Register() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post("http://localhost:3000/api/auth/register", {
+      const res = await axios.post("/auth/register", {
         name,
         email,
         password,

--- a/refer-app/src/pages/Services.jsx
+++ b/refer-app/src/pages/Services.jsx
@@ -8,7 +8,7 @@ export default function Services() {
 
   const fetchServices = async () => {
     try {
-      const res = await axios.get("http://localhost:3000/api/services/mine");
+      const res = await axios.get("/services/mine");
       setServices(res.data);
     } catch (err) {
       console.error("Failed to fetch services", err);
@@ -18,7 +18,7 @@ export default function Services() {
   const handleCreate = async (e) => {
     e.preventDefault();
     try {
-      await axios.post("http://localhost:3000/api/services", {
+      await axios.post("/services", {
         title,
         reward,
       });


### PR DESCRIPTION
## Summary
- use configured axios client in login, register and services pages
- mention the `VITE_API_BASE` env var for the frontend

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684caa206a308322bc2fb6b3314d8968