### PR TITLE
Fix Tailwind CSS postcss setup

### DIFF
--- a/refer-app/README.md
+++ b/refer-app/README.md
@@ -20,6 +20,8 @@ npm install
 ```
 
 Tailwind CSS is configured through `tailwind.config.js` and `postcss.config.js`.
+If you upgrade to Tailwind CSS v4 or later, install the `@tailwindcss/postcss`
+package and include it in `postcss.config.js`.
 
 ## Development
 

--- a/refer-app/package.json
+++ b/refer-app/package.json
@@ -16,7 +16,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0",
-    "tailwindcss": "^4.1.6"
+    "tailwindcss": "^4.1.6",
+    "@tailwindcss/postcss": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/refer-app/postcss.config.js
+++ b/refer-app/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- install `@tailwindcss/postcss` for Tailwind v4
- use the new plugin in `postcss.config.js`
- document the extra dependency in the React README

## Testing
- `npm run lint` *(fails: 'friends' is assigned a value but never used, etc.)*
- `npm test` in `refer-backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ccfd1ef9c83229752e7818302b6a1